### PR TITLE
Context file to match approved draft

### DIFF
--- a/v2023.json
+++ b/v2023.json
@@ -1,0 +1,120 @@
+{
+  "@context": [
+      "https://opensource.ieee.org/scd/v2023.json",
+          {
+            "@version": "2023",
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "CompetencyDefinition": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#CompetencyDefinition",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "competencyStatement": "rdf:langString",
+                    "competencyLevel": "RubricCriterionLevel",
+                    "description": "rdf:langString",
+                    "hasCompetencyFramework": "@id",
+                    "hasCriterion": "Criterion",
+                    "id": "@id",
+                    "name": "rdf:langString",
+                    "referenceCode": "rdf:Literal",
+                    "resourceAssociation": "rdfs:Resource",
+        		    "competencyType": "skos:Concept",
+        		    "competencyTypeLabel": "rdf:langString"
+                }
+            },
+
+            "CompetencyFramework": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#CompetencyFramework",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",  
+
+                    "name": "rdf:langString",
+                    "description": "rdf:langString",
+                    "hasCompetencyDefinition": "CompetencyDefinition",
+                    "hasRubric": "Rubric",
+                    "id": "@id",
+                    "originalFramework": "rdfs:Resource",
+                    "resourceAssociation": "ResourceAssociaiton"
+                }
+            },
+
+            "CompetencyAssociation": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#CompetencyAssociation",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "associationType": "skos:Concept",
+                    "destination": "rdfs:Resource",
+                    "id": "@id",
+                    "source": "rdfs:Resource",
+                    "hasCompetencyFramrwork": "CompetencyFramework",
+                    "weight": "rdfs:Literal"
+                }
+            },
+
+            "Rubric": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#Rubric",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "id": "@id",
+                    "description":"rdf:langString",
+                    "method":"skos:Concept",
+                    "name":"rdf:langString",
+                    "rubricCriterion":"RubricCriterion"
+                }
+            },
+                
+            "RubricCriterion": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#RubricCriterion",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+                    
+                    "id": "@id",
+                    "name": "rdf:langString",
+                    "category": "rdf:langString",
+                    "description": "rdf:langString",
+                    "position": "rdf:langString",
+                    "rubricCriterionLevel": "RubricCriterionLevel",
+                    "weight": "rdfs:Literal"
+                }
+            },
+                
+            "RubricCriterionLevel": {
+                "@id": "https://opensource.ieee.org/scd/v2023.json#RubricCriterionLevel",
+                "@context": {
+                    "@version": "2023",
+                    "@protected": true,
+                    "type": "@type",
+                    "schema": "http://schema.org/",
+
+                    "id": "@id",
+                    "name": "rdf:langString",
+                    "description": "rdf:langString",
+                    "feedback": "rdf:langString",
+                    "position": "rdfs:Literal",
+                    "score": "rdfs:Literal"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This new file matches the approved draft terms and ranges... except the property "type" was used in the CompetencyDefinition class so I changed it to competencyType here. (I'll post an issue about this. Maybe we need to fix typo in standard if there is no workaround.)